### PR TITLE
Add plotting range flag

### DIFF
--- a/bin/plot_tractometry_results
+++ b/bin/plot_tractometry_results
@@ -116,7 +116,7 @@ def plot_tractometry_with_pvalue(values, meta_data, bundles, selected_bundles, o
                                  analysis_type, correct_mult_tract_comp, show_detailed_p, nperm=1000,
                                  hide_legend=False, plot_3D_path=None, plot_3D_type="none",
                                  tracking_format="trk_legacy", tracking_dir="auto", show_color_bar=True,
-                                 save_csv=False):
+                                 save_csv=False, y_range=[0, 1]):
 
     NR_POINTS = values[meta_data["subject_id"][0]].shape[1]
     selected_bun_indices = [bundles.index(b) for b in selected_bundles]
@@ -275,7 +275,7 @@ def plot_tractometry_with_pvalue(values, meta_data, bundles, selected_bundles, o
 
             plot_utils.plot_bundles_with_metric(tracking_path, ending_path, mask_path, bundle, metric,
                                                 output_path_3D, tracking_format, show_color_bar)
-
+        ax.set_ylim(y_range[0], y_range[-1])
 
     plt.tight_layout()
     plt.savefig(output_path, dpi=200)
@@ -283,6 +283,12 @@ def plot_tractometry_with_pvalue(values, meta_data, bundles, selected_bundles, o
     if save_csv:
         results_df.to_csv(output_path + ".csv")
 
+def two_floats(value):
+    values = value.split()
+    if len(values) != 2:
+        raise argparse.ArgumentError
+    values = [float(x) for x in values]
+    return values
 
 def main():
     parser = argparse.ArgumentParser(description="Test for significant differences and plot tractometry results.",
@@ -310,6 +316,9 @@ def main():
                         help="If using --plot3D you have to specify the format of the trackings which will get loaded."
                              "(default: trk_legacy)",
                         default="trk_legacy")
+    parser.add_argument('--range', '-r', metavar='n,n', default=[0, 1], type=two_floats,
+                        help='Range of metric (y-axis) to plot. '
+                        'Default: 0, 1')
     args = parser.parse_args()
 
     # Choose how to define significance: by corrected alphaFWE or by clusters of values smaller than uncorrected alpha
@@ -347,6 +356,10 @@ def main():
         print("Number of subjects: {}".format(len(meta_data)))
     else:
         raise ValueError("Invalid second column header (only 'group' or 'target' allowed)")
+    
+    if len(args.range) != 2:
+        raise ValueError('Invalid range {}. Please enter lower bound and upper bound '
+                         'separated by a space. e.g. 0 1'.foramt(args.range))
 
     all_bundles = dataset_specific_utils.get_bundle_names("All_tractometry")[1:]
 
@@ -363,7 +376,7 @@ def main():
                                  show_detailed_p, nperm=nperm, hide_legend=hide_legend,
                                  plot_3D_path=plot_3D_path, plot_3D_type=args.plot3D,
                                  tracking_format=args.tracking_format, tracking_dir=args.tracking_dir,
-                                 show_color_bar=show_color_bar, save_csv=args.save_csv)
+                                 show_color_bar=show_color_bar, save_csv=args.save_csv, y_range=args.range)
 
 
 if __name__ == '__main__':

--- a/bin/plot_tractometry_results
+++ b/bin/plot_tractometry_results
@@ -320,8 +320,8 @@ def main():
                         help="If using --plot3D you have to specify the format of the trackings which will get loaded."
                              "(default: trk_legacy)",
                         default="trk_legacy")
-    parser.add_argument('--range', '-r', metavar='n,n', default=None, type=two_floats,
-                        help='Range of metric (y-axis) to plot. '
+    parser.add_argument('--range', '-r', metavar='l u', default=None, type=two_floats,
+                        help='Range of metric (y-axis) to plot. Specify lower (l) and upper (u) bound'
                         'Default: None')
     args = parser.parse_args()
 
@@ -363,7 +363,7 @@ def main():
     if args.range is not None:
         if len(args.range) != 2:
             raise ValueError('Invalid range {}. Please enter lower bound and upper bound '
-                            'separated by a space. e.g. 0 1'.foramt(args.range))
+                            'separated by a space. e.g. 0.0 1.1'.format(args.range))
 
     all_bundles = dataset_specific_utils.get_bundle_names("All_tractometry")[1:]
 

--- a/bin/plot_tractometry_results
+++ b/bin/plot_tractometry_results
@@ -116,7 +116,7 @@ def plot_tractometry_with_pvalue(values, meta_data, bundles, selected_bundles, o
                                  analysis_type, correct_mult_tract_comp, show_detailed_p, nperm=1000,
                                  hide_legend=False, plot_3D_path=None, plot_3D_type="none",
                                  tracking_format="trk_legacy", tracking_dir="auto", show_color_bar=True,
-                                 save_csv=False, y_range=[0, 1]):
+                                 save_csv=False, y_range=None):
 
     NR_POINTS = values[meta_data["subject_id"][0]].shape[1]
     selected_bun_indices = [bundles.index(b) for b in selected_bundles]
@@ -275,7 +275,8 @@ def plot_tractometry_with_pvalue(values, meta_data, bundles, selected_bundles, o
 
             plot_utils.plot_bundles_with_metric(tracking_path, ending_path, mask_path, bundle, metric,
                                                 output_path_3D, tracking_format, show_color_bar)
-        ax.set_ylim(y_range[0], y_range[-1])
+        if y_range is not None:
+            ax.set_ylim(y_range[0], y_range[-1])
 
     plt.tight_layout()
     plt.savefig(output_path, dpi=200)
@@ -284,10 +285,13 @@ def plot_tractometry_with_pvalue(values, meta_data, bundles, selected_bundles, o
         results_df.to_csv(output_path + ".csv")
 
 def two_floats(value):
-    values = value.split()
-    if len(values) != 2:
-        raise argparse.ArgumentError
-    values = [float(x) for x in values]
+    if value is None:
+        values = None
+    else:
+        values = value.split()
+        if len(values) != 2:
+            raise argparse.ArgumentError
+        values = [float(x) for x in values]
     return values
 
 def main():
@@ -316,9 +320,9 @@ def main():
                         help="If using --plot3D you have to specify the format of the trackings which will get loaded."
                              "(default: trk_legacy)",
                         default="trk_legacy")
-    parser.add_argument('--range', '-r', metavar='n,n', default=[0, 1], type=two_floats,
+    parser.add_argument('--range', '-r', metavar='n,n', default=None, type=two_floats,
                         help='Range of metric (y-axis) to plot. '
-                        'Default: 0, 1')
+                        'Default: None')
     args = parser.parse_args()
 
     # Choose how to define significance: by corrected alphaFWE or by clusters of values smaller than uncorrected alpha
@@ -356,10 +360,10 @@ def main():
         print("Number of subjects: {}".format(len(meta_data)))
     else:
         raise ValueError("Invalid second column header (only 'group' or 'target' allowed)")
-    
-    if len(args.range) != 2:
-        raise ValueError('Invalid range {}. Please enter lower bound and upper bound '
-                         'separated by a space. e.g. 0 1'.foramt(args.range))
+    if args.range is not None:
+        if len(args.range) != 2:
+            raise ValueError('Invalid range {}. Please enter lower bound and upper bound '
+                            'separated by a space. e.g. 0 1'.foramt(args.range))
 
     all_bundles = dataset_specific_utils.get_bundle_names("All_tractometry")[1:]
 


### PR DESCRIPTION
Adds the flag `--range n n` or `-r n n` to `plot_tractometry_results` to allow standardization of y-limits. This allows one to compare metric values across ROIs. Also helpful when plotting other DTI/DKI metrics.

For example, the command below plots mean kurtosis (MK) from -0.1 to 2.
```
plot_tractometry_results -i /Users/dataprocessing/Documents/IAM/TractSeg/subjects_MK.txt \
-o /Users/dataprocessing/Documents/IAM/TractSeg/tractometry_result_mk.png \
--mc --range -0.1 2.1
```

![tractometry_result_mk](https://user-images.githubusercontent.com/55592651/83928097-8fd2ad00-a75c-11ea-94de-a1978465f351.png)