### PR TITLE
Checking streamline orientation and startpoint within beginnings mask

### DIFF
--- a/tractseg/libs/fiber_utils.py
+++ b/tractseg/libs/fiber_utils.py
@@ -460,27 +460,25 @@ def get_idxs_of_closest_points(streamlines, target_point):
     return idxs
 
 
-def orient_to_same_start_region(streamlines, beginnings):
+def orient_to_same_start_region(streamlines, beginnings, mm2vox):
     # (we could also use dipy.tracking.streamline.orient_by_streamline instead)
-    streamlines = add_to_each_streamline(streamlines, 0.5)
+    
+    # convert mm2vox only for *first and last* streamline point coordinate
+    term_points = [nib.affines.apply_affine(mm2vox, s[[0, -1]]).round().astype(int) for s in streamlines]
+    
+    # check and flip
     streamlines_new = []
-    ss = beginnings.shape
-    for idx, sl in enumerate(streamlines):
-        startpoint = sl[0]
-        # Flip streamline if not in right order
-        #
-        # Somehow somtimes the startpoint is outside of the image dimensions. This should
-        # not happen since the tracking was all done within these image dimensions. Maybe
-        # the smoothing or compression slightly moves it out of image. Therefore we check
-        # here if it is within the image and if not we discard this streamline
-        x, y, z = int(startpoint[0]), int(startpoint[1]), int(startpoint[2])
-        if x >= 0 and x < ss[0] and \
-            y >= 0 and y < ss[1] and \
-            z >= 0 and z < ss[2]:
-            if beginnings[int(startpoint[0]), int(startpoint[1]), int(startpoint[2])] == 0:
-                sl = sl[::-1, :]
-            streamlines_new.append(sl)
-        else:
+    for sl, tp in zip(streamlines, term_points):
+        if beginnings[tuple(tp[0])]: # if correctly oriented
+            streamlines_new.append(sl) # do not flip
+        elif beginnings[(tuple(tp[1]))]: # if endpoint is in beginnings mask
+            streamlines_new.append(sl[::-1]) # flip it around
+        else: # if neither are in beginnings mask, discard
             print("WARNING: steamline startpoint out of image. Discarding this streamline.")
-    streamlines_new = add_to_each_streamline(streamlines_new, -0.5)
+            
+    # check now to make sure all of them are properly oriented
+    startpoints_new = [nib.affines.apply_affine(mm2vox, s[0]).round().astype(int) for s in streamlines_new]
+    if not all([beginnings[tuple(sp)] for sp in startpoints_new]):
+        print("WARNING: not all resulting streamlines have been flipped")
+    
     return streamlines_new

--- a/tractseg/libs/plot_utils.py
+++ b/tractseg/libs/plot_utils.py
@@ -391,8 +391,11 @@ def plot_bundles_with_metric(bundle_path, endings_path, brain_mask_path, bundle,
     # Reduce streamline count
     streamlines = streamlines[::2]
 
+    # Grab affine inverse for coordinate space transformations
+    mm2vox = np.linalg.inv(beginnings_img.affine).dot(sl_file.affine)
+
     # Reorder to make all streamlines have same start region
-    streamlines = fiber_utils.orient_to_same_start_region(streamlines, beginnings)
+    streamlines = fiber_utils.orient_to_same_start_region(streamlines, beginnings, mm2vox)
 
     if algorithm == "distance_map" or algorithm == "equal_dist":
         streamlines = fiber_utils.resample_fibers(streamlines, NR_SEGMENTS * ANTI_INTERPOL_MULT)


### PR DESCRIPTION
As per discussion in issue #147, seems like the streamline point coordinates are in RAS+ space. Here, I:
* Added affine inverse as third argument necessary for mm2vox mapping
* Check whether first or last coordinate fall into the `beginnings` mask
* Retain, flip, or discard streamline accordingly
* Verify that all new streamline startpoints are now within the `beginnings` mask