### PR TITLE
fix variable referenced before assignment when using no_filtering_by_…

### DIFF
--- a/tractseg/libs/tracking.py
+++ b/tractseg/libs/tracking.py
@@ -90,6 +90,8 @@ def track(bundle, peaks, output_dir, tracking_on_FODs, tracking_software, tracki
                                                 output_dir + "/bundle_segmentations" + dir_postfix + "/" +
                                                 bundle + ".nii.gz",
                                                 tracking_format=output_format)
+            shutil.rmtree(tmp_dir)
+            return
 
         # Filtering
 


### PR DESCRIPTION
…endpoints, and unecessary if statement

When running `Tracking` with `--no_filtering_by_endpoints` the variables `bundle_mask_ok`, `beginnings_mask_ok`, `endings_mask_ok` are referenced before assignment in the first if statement below the `### Tracking ###` comment.
Fixed by moving all the code for `filtering_by_endpoints = True` into the original if statement, and removing the `if filter_by_endpoints` in the original if statement underneath `### Tracking ###`.
Tested `Tracking` both with `--no_filtering_by_endpoints` and without flag, with flag now runs, without produces similar tracts as before.