### PR TITLE
Replace deprecated pkg_resources with importlib

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         # python-version: [3.8, 3.9]  # too many calls to zenodo download -> request limit
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{matrix.python-version}}
@@ -19,7 +19,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest Cython
-          pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torch==1.9.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install .
 
       - name: Run test script

--- a/bin/TractSeg
+++ b/bin/TractSeg
@@ -10,7 +10,7 @@ import importlib
 import os
 from os.path import join
 import sys
-from pkg_resources import require
+from importlib.metadata import version
 import nibabel as nib
 
 from tractseg.libs.system_config import get_config_name
@@ -159,7 +159,7 @@ def main():
     parser.add_argument("--verbose", action="store_true", help="Show more intermediate output",
                         default=False)
 
-    parser.add_argument('--version', action='version', version=require("TractSeg")[0].version)
+    parser.add_argument('--version', action='version', version=version("TractSeg"))
 
     args = parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='TractSeg',
         url='https://github.com/MIC-DKFZ/TractSeg/',
         author='Jakob Wasserthal',
         author_email='j.wasserthal@dkfz-heidelberg.de',
-        python_requires='>=3.5',
+        python_requires='>=3.9',
         license='Apache 2.0',
         packages=find_packages(),
         install_requires=[

--- a/tractseg/libs/img_utils.py
+++ b/tractseg/libs/img_utils.py
@@ -7,7 +7,7 @@ import sys
 import joblib
 from joblib import Parallel, delayed
 from os.path import join
-from pkg_resources import resource_filename
+from importlib.resources import files, as_file
 
 import psutil
 import numpy as np
@@ -671,8 +671,9 @@ def flip_peaks_to_correct_orientation_if_needed(peaks_input, do_flip=False):
         X = [list(peaks_x.flatten()) + list(peaks_y.flatten()) + list(peaks_z.flatten())]
         X = np.nan_to_num(X)
 
-        random_forest_path = resource_filename('tractseg.resources', 'random_forest_peak_orientation_detection.pkl')
-        clf = joblib.load(random_forest_path)
+        resource = files('tractseg.resources').joinpath('random_forest_peak_orientation_detection.pkl')
+        with as_file(resource) as random_forest_path:
+            clf = joblib.load(random_forest_path)
         predicted_label = clf.predict(X)[0]
         # labels:
         #  ok: 0, x:1, y:2, z:3


### PR DESCRIPTION
Replace deprecated `pkg_resources` with `importlib.metadata` and `importlib.resources`, which are part of the Python standard library. 

(`pkg_resources` has been causing import-time issues for some downstream libraries that depend on TractSeg)

Minimum Python version is bumped from 3.5 to 3.9 (required by `importlib.resources.files()`). Python 3.8 has been EOL since Oct 2024 and PyTorch already requires 3.9+, so this should not affect anyone in practice.

No changes to the TractSeg CLI or Python API.

This should cause no behavioral differences for anyone on Python 3.9+.